### PR TITLE
[feature] build lpm exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Install Inno Setup silently
         run: .\is.exe /verysilent /dir="C:\Program Files\InnoSetup"
 
-      - name: Create the EXE Installer
-        working-directory: ./utils
-        run: ./BuildInstaller.bat
-
       - name: Code Signing Setup - Setup Certificate
         shell: bash
         run: echo "${{secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
@@ -52,7 +48,27 @@ jobs:
           C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
           smksp_cert_sync.exe
 
-      - name: Code Signing Setup - Sign using Signtool
+      - name: Setup python virtual environment
+        run: |
+          python -m venv .venv
+          .venv\Scripts\Activate
+          pip install -r requirements.dev.txt
+
+      - name: Create the EXE Installer
+        working-directory: ./utils
+        run:
+          ./BuildExecutable.bat
+
+      - name: Code Signing Setup - Sign Executable using Signtool
+        run: |
+          signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "./dist/LPM.exe"
+          signtool.exe verify /v /pa "./dist/LPM.exe"
+
+      - name: Create the EXE Installer
+        working-directory: ./utils
+        run: ./BuildInstaller.bat
+
+      - name: Code Signing Setup - Sign Installer using Signtool
         run: |
           signtool.exe sign /sha1 ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "./build/LPM-Setup.exe"
           signtool.exe verify /v /pa "./build/LPM-Setup.exe"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,4 @@
+pytest==8.3.4
+pyinstaller==6.11.1
+
+. requirements.txt

--- a/src/LPM.cmd
+++ b/src/LPM.cmd
@@ -1,1 +1,0 @@
-@python "%~dp0\LPM.py" %*

--- a/utils/BuildExecutable.bat
+++ b/utils/BuildExecutable.bat
@@ -1,0 +1,2 @@
+cd ..
+pyinstaller --onefile --clean --add-data src\version.json:. --icon=files\favicon.ico src\LPM.py

--- a/utils/BuildExecutable.bat
+++ b/utils/BuildExecutable.bat
@@ -1,2 +1,2 @@
 cd ..
-pyinstaller --onefile --clean --add-data src\version.json:. --icon=files\favicon.ico src\LPM.py
+pyinstaller --onefile --clean --add-data src\version.json:. --version-file="version.txt" --icon=files\favicon.ico src\LPM.py 

--- a/utils/Setup.iss
+++ b/utils/Setup.iss
@@ -5,7 +5,7 @@
 #define MyAppVersion "1.0.6"
 #define MyAppPublisher "Loupe"
 #define MyAppURL "https://loupe.team/"
-#define MyAppExeName "LPM.cmd"
+#define MyAppExeName "LPM.exe"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -39,32 +39,15 @@ AlwaysRestart=yes
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "..\src\*.py"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\src\LPM.cmd"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\src\version.json"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\requirements.txt"; DestDir: "{app}"; Flags: ignoreversion
-; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+Source: "..\dist\LPM.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}";
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait skipifsilent
-Filename: "{cmd}"; Parameters: "/C pip install -r ""{app}\requirements.txt"""; Description: "Installing Python dependencies..."; StatusMsg: "Installing dependencies..."; Check: PythonAndPipExist()
 
 [Code]
-
-{ ///////////////////////////////////////////////////////////////////// }
-function PythonAndPipExist(): Boolean;
-var
-  ErrorCode: Integer;
-begin
-  if Exec('python', '--version', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) and 
-     Exec('pip', '--version', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
-    Result := True
-  else
-    Result := False;
-end;
 
 { ///////////////////////////////////////////////////////////////////// }
 function GetUninstallString(): String;

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,33 @@
+# UTF-8
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(1, 0, 6, 1),
+    prodvers=(1, 0, 6, 1),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x4,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo(
+      [
+        StringTable(
+          u'040904B0',
+          [
+            StringStruct(u'CompanyName', u'Loupe'),
+            StringStruct(u'FileDescription', u'LPM is the Loupe Package Manager voor B&R Automation Studio'),
+            StringStruct(u'FileVersion', u'1.0.6'),
+            StringStruct(u'InternalName', u'LPM'),
+            StringStruct(u'LegalCopyright', u'Copyright (C) 2023 Loupe, All rights reserved.'),
+            StringStruct(u'ProductName', u'LPM'),
+            StringStruct(u'ProductVersion', u'1.0.0'),
+            StringStruct(u'ApplicationName', u'LPM.exe')
+          ]
+        )
+      ]
+    ),
+    VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
+  ]
+)


### PR DESCRIPTION
## What:
Script to build standalone executable with pyinstaller.

Git workflow is update to:
* use a virtual env
* build the executable
* sign the exectutable before packed with the installer.

The workflow changes are not tested, because of no access to this environment.

## Why:
Make the user easier by preventing the user have to install `python` or mess up their global python environment.
Remark you still need to install `nodejs`.