### PR TITLE
[fix] overwrite of exisitng .npmrc

### DIFF
--- a/src/LPM.py
+++ b/src/LPM.py
@@ -473,11 +473,21 @@ def importLibraries():
 
 # Login silently by manually creating a the .npmrc file in the user directory.
 def login(token):
-    f = open(os.path.join(os.path.expanduser('~'), '.npmrc'), 'w')
-    text = []
-    text.append('@loupeteam:registry=https://npm.pkg.github.com')
-    text.append('//npm.pkg.github.com/:_authToken=' + token)
-    f.write('\n'.join(text))
+    npm_cfg_file = os.path.join(os.path.expanduser('~'), '.npmrc')
+    f = open(npm_cfg_file, 'r')
+    content = f.readlines()
+    f.close()
+    try:
+        idx = content.index('@loupeteam:registry=https://npm.pkg.github.com')
+        # no expection; already present lets update the token
+        content[idx+1] = '//npm.pkg.github.com/:_authToken=' + token
+    except ValueError as _exp:
+        # Ok not present lets add it
+        content.append('@loupeteam:registry=https://npm.pkg.github.com')
+        content.append('//npm.pkg.github.com/:_authToken=' + token)
+
+    f = open(npm_cfg_file, 'w')
+    f.write('\n'.join(content))
     f.close()
 
 # Logout of the Github registry.  


### PR DESCRIPTION
## What:
Code changed to add the loupe registry in a safe way to `~/.npmrc`:
* read the content of  `~/.npmrc`
* add or update the loupe registry
* write the content back to file

## Why:
LPM overwrites an existing `~/.npmrc` file. On logout it even clears the file.
When also working on webproject and node projects, it's not very practical that file is reset after LPM ussage.

